### PR TITLE
Populate bombs based on probability rather than randomly

### DIFF
--- a/Cell.java
+++ b/Cell.java
@@ -13,14 +13,17 @@ public class Cell extends JButton {
     public boolean isRevealed;
 
     void markUnknown() {
+        this.setForeground(Color.BLACK);
         this.setBackground(Color.YELLOW);
     }
 
     void markSafe() {
+        this.setForeground(Color.BLACK);
         this.setBackground(Color.GREEN);
     }
 
     void markBomb() {
+        this.setForeground(Color.BLACK);
         this.setBackground(Color.RED);
     }
 

--- a/Cell.java
+++ b/Cell.java
@@ -107,11 +107,11 @@ public class Cell extends JButton {
 
     // explanation for the calculation of the probabilty of a cell 
     // being a bomb can be found here: https://www.desmos.com/calculator/vo8q8z5ecx
-    double calculateProbabilityOfBomb(int x, int y, int gridSize) {
+    double calculateProbabilityOfBomb(int x, int y, int gridSize, int maxProbability) {
         // we use the simple grid distance because 
         // it is computationally faster than pythagora
         double distance = Math.abs(y - this.row) + Math.abs(x - this.col);
-        double probability = (2 / (15 * Math.PI)) * Math.atan((distance * distance) / gridSize);
+        double probability = (maxProbability / 100.0) * (2 / Math.PI) * Math.atan((distance * distance) / gridSize);
 
         return probability;
     }

--- a/Cell.java
+++ b/Cell.java
@@ -106,7 +106,7 @@ public class Cell extends JButton {
     }
 
     // explanation for the calculation of the probabilty of a cell 
-    // being a bomb can be found here: https://www.desmos.com/calculator/vo8q8z5ecx
+    // being a bomb can be found here: https://www.desmos.com/calculator/b3lcshvkvg
     double calculateProbabilityOfBomb(int x, int y, int gridSize, int maxProbability) {
         // we use the simple grid distance because 
         // it is computationally faster than pythagora

--- a/Cell.java
+++ b/Cell.java
@@ -1,5 +1,4 @@
 import javax.swing.*;
-import javax.swing.plaf.ColorUIResource;
 
 import java.awt.*;
 
@@ -100,6 +99,16 @@ public class Cell extends JButton {
             this.isFlagged = false;
             setIcon(null);
         }
+    }
+
+    // explanation for the calculation of the probabilty of a cell 
+    // being a bomb can be found here: https://www.desmos.com/calculator/pc2irxrb6e
+    double calculateProbabilityOfBomb(int x, int y, int gridSize) {
+        // we use the simple grid distance because it is computationally faster
+        double distance = Math.abs(y - this.row) + Math.abs(x - this.col);
+        double probability = (2 / Math.PI) * Math.atan((distance * distance) / Math.pow(gridSize, 3));
+
+        return probability;
     }
 
     Cell(int row, int col) {

--- a/Cell.java
+++ b/Cell.java
@@ -82,6 +82,7 @@ public class Cell extends JButton {
 
         setBackground(Color.LIGHT_GRAY);
         setBorder(BorderFactory.createLineBorder(Color.GRAY, 1));
+        setText("");
     }
 
     void toggleFlag() {
@@ -102,11 +103,12 @@ public class Cell extends JButton {
     }
 
     // explanation for the calculation of the probabilty of a cell 
-    // being a bomb can be found here: https://www.desmos.com/calculator/pc2irxrb6e
+    // being a bomb can be found here: https://www.desmos.com/calculator/vo8q8z5ecx
     double calculateProbabilityOfBomb(int x, int y, int gridSize) {
-        // we use the simple grid distance because it is computationally faster
+        // we use the simple grid distance because 
+        // it is computationally faster than pythagora
         double distance = Math.abs(y - this.row) + Math.abs(x - this.col);
-        double probability = (2 / Math.PI) * Math.atan((distance * distance) / Math.pow(gridSize, 3));
+        double probability = (2 / (15 * Math.PI)) * Math.atan((distance * distance) / gridSize);
 
         return probability;
     }

--- a/Game.java
+++ b/Game.java
@@ -23,6 +23,8 @@ public class Game extends JFrame{
     public boolean gameOver;
     public boolean hintMode;
     public boolean autoSolve;
+
+    public int maxProbability;
     public boolean drawProbabilities;
     public boolean drawPopulationRings;
 
@@ -174,7 +176,7 @@ public class Game extends JFrame{
                     Cell currentCell = this.cells[y][x];
 
                     double randomDouble = random.nextDouble(0, 1);
-                    double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
+                    double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize, this.maxProbability);
 
                     if (randomDouble < probability) {
                         currentCell.makeBomb();
@@ -226,8 +228,8 @@ public class Game extends JFrame{
                     continue;
                 }
 
-                double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
-                double intensity = probability * 15 * 255;
+                double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize, this.maxProbability);
+                double intensity = probability * (100 / this.maxProbability) * 255;
 
                 currentCell.setBackground(new Color(0, 0, (int)(intensity)));
                 currentCell.setForeground(Color.YELLOW);
@@ -402,14 +404,17 @@ public class Game extends JFrame{
         this.mainLabel.setText("B)");
     }
 
-    public Game(int gridSize, int bombAmount, boolean useProbability, boolean drawProbabilities, boolean drawPopulationRings){
+    public Game(int gridSize, int bombAmount, int maxProbability, 
+                boolean useProbability, boolean drawProbabilities, boolean drawPopulationRings){
         this.firstCell = null;
 
         this.gameOver = false;
         this.hintMode = false;
         this.autoSolve = false;
+
         this.drawProbabilities = drawProbabilities;
         this.drawPopulationRings = drawPopulationRings;
+        this.maxProbability = maxProbability;
 
         this.cellSize = 35;
         this.gridSize = gridSize;

--- a/Game.java
+++ b/Game.java
@@ -24,6 +24,7 @@ public class Game extends JFrame{
     public boolean hintMode;
     public boolean autoSolve;
     public boolean drawProbabilities;
+    public boolean drawPopulationRings;
 
     public int gridSize;
     public int cellSize;
@@ -64,7 +65,7 @@ public class Game extends JFrame{
         // if disabling hint mode, reset color of all cells unrevealed
         // also do this if gameover
         if(!this.hintMode || this.gameOver) {
-            this.resetCellsColor();
+            this.resetCells();
 
             return;
         }
@@ -85,7 +86,7 @@ public class Game extends JFrame{
         this.solveSituation();
     }
 
-    public void resetCellsColor() {
+    public void resetCells() {
 
         if (this.drawProbabilities) {
             this.paintProbabilities();
@@ -102,6 +103,7 @@ public class Game extends JFrame{
                 }
 
                 currentCell.setBackground(new Color(180, 180, 180));
+                currentCell.setText("");
             }
         }
     }
@@ -165,9 +167,11 @@ public class Game extends JFrame{
 
                     Cell currentCell = this.cells[y][x];
 
-                    //currentCell.setBackground(d % 2 == 0 ? Color.WHITE : Color.BLACK);
-                    //currentCell.setForeground(d % 2 == 0 ? Color.BLACK : Color.WHITE);
-                    //currentCell.setText(String.valueOf(d));
+                    if (this.drawPopulationRings) {
+                        currentCell.setBackground(d % 2 == 0 ? Color.WHITE : Color.BLACK);
+                        currentCell.setForeground(d % 2 == 0 ? Color.BLACK : Color.WHITE);
+                        currentCell.setText(String.valueOf(d));
+                    }
 
                     double randomDouble = random.nextDouble(0, 1);
                     double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
@@ -355,13 +359,14 @@ public class Game extends JFrame{
         this.mainLabel.setText("B)");
     }
 
-    public Game(int gridSize, int bombAmount, boolean useProbability, boolean drawProbabilities){
+    public Game(int gridSize, int bombAmount, boolean useProbability, boolean drawProbabilities, boolean drawPopulationRings){
         this.firstCell = null;
 
         this.gameOver = false;
         this.hintMode = false;
         this.autoSolve = false;
         this.drawProbabilities = drawProbabilities;
+        this.drawPopulationRings = drawPopulationRings;
 
         this.cellSize = 35;
         this.gridSize = gridSize;

--- a/Game.java
+++ b/Game.java
@@ -94,6 +94,12 @@ public class Game extends JFrame{
             return;
         }
 
+        if (this.drawPopulationRings) {
+            this.paintPopulationRings();
+
+            return;
+        }
+
         for(int y = 0; y < this.gridSize; y++) {
             for(int x = 0; x < this.gridSize; x++) {
                 Cell currentCell = this.cells[y][x];
@@ -167,12 +173,6 @@ public class Game extends JFrame{
 
                     Cell currentCell = this.cells[y][x];
 
-                    if (this.drawPopulationRings) {
-                        currentCell.setBackground(d % 2 == 0 ? Color.WHITE : Color.BLACK);
-                        currentCell.setForeground(d % 2 == 0 ? Color.BLACK : Color.WHITE);
-                        currentCell.setText(String.valueOf(d));
-                    }
-
                     double randomDouble = random.nextDouble(0, 1);
                     double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
 
@@ -232,6 +232,49 @@ public class Game extends JFrame{
                 currentCell.setBackground(new Color(0, 0, (int)(intensity)));
                 currentCell.setForeground(Color.YELLOW);
                 currentCell.setText((int)(probability * 100) + "%");
+            }
+        }
+    }
+
+    // this method serves as a demonstation
+    // that the way the iteration is done 
+    // in the probability population method 
+    // works as intended
+    public void paintPopulationRings() {
+        int largestRing = 1 + this.gridSize - Math.min(this.firstCell.row, this.firstCell.col);
+
+        for (int d = 1; d <= largestRing; d++) {
+            for (int y = this.firstCell.row - d; y <= this.firstCell.row + d; y++) {
+ 
+                // skip if out of bounds
+                if (y < 0 || y >= this.gridSize) {
+                    continue;
+                }
+
+                for (int x = this.firstCell.col - d; x <= this.firstCell.col + d; x++) {
+
+                    // skip if inside ring (dont want to iterate over previous ring)
+                    if (x > this.firstCell.col - d  && x < this.firstCell.col + d &&
+                        y > this.firstCell.row - d  && y < this.firstCell.row + d ) {
+                        continue;
+                    }
+
+                    // skip if out of bounds
+                    if (x < 0 || x >= this.gridSize) {
+                        continue;
+                    }
+
+                    Cell currentCell = this.cells[y][x];
+
+                    // skip if revealed
+                    if (currentCell.isRevealed) {
+                        continue;
+                    }
+
+                    currentCell.setBackground(d % 2 == 0 ? Color.WHITE : Color.BLACK);
+                    currentCell.setForeground(d % 2 == 0 ? Color.BLACK : Color.WHITE);
+                    currentCell.setText(String.valueOf(d));
+                }
             }
         }
     }
@@ -519,6 +562,9 @@ public class Game extends JFrame{
 
                                 if (self.drawProbabilities) {
                                     self.paintProbabilities();
+                                }
+                                if (self.drawPopulationRings) {
+                                    self.paintPopulationRings();
                                 }
                             }
 

--- a/Game.java
+++ b/Game.java
@@ -140,20 +140,34 @@ public class Game extends JFrame{
         // located around the corners, whereas this way we 
         // dont get rid of most of the available bombs right 
         // away
+        int largestRing = 1 + this.gridSize - Math.min(this.firstCell.row, this.firstCell.col);
         ringloop:
-        for (int d = 0; d < this.gridSize / 2; d++) {
-            for (int y = this.firstCell.row - d; y < this.firstCell.row + d; y++) {
+        for (int d = 1; d <= largestRing; d++) {
+            for (int y = this.firstCell.row - d; y <= this.firstCell.row + d; y++) {
  
+                // skip if out of bounds
                 if (y < 0 || y >= this.gridSize) {
                     continue;
                 }
 
-                for (int x = this.firstCell.col - d; x < this.firstCell.col + d; x++) {
+                for (int x = this.firstCell.col - d; x <= this.firstCell.col + d; x++) {
+
+                    // skip if inside ring (dont want to iterate over previous ring)
+                    if (x > this.firstCell.col - d  && x < this.firstCell.col + d &&
+                        y > this.firstCell.row - d  && y < this.firstCell.row + d ) {
+                        continue;
+                    }
+
+                    // skip if out of bounds
                     if (x < 0 || x >= this.gridSize) {
                         continue;
                     }
 
                     Cell currentCell = this.cells[y][x];
+
+                    //currentCell.setBackground(d % 2 == 0 ? Color.WHITE : Color.BLACK);
+                    //currentCell.setForeground(d % 2 == 0 ? Color.BLACK : Color.WHITE);
+                    //currentCell.setText(String.valueOf(d));
 
                     double randomDouble = random.nextDouble(0, 1);
                     double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
@@ -170,6 +184,7 @@ public class Game extends JFrame{
             }
         }
 
+        // if we haven't finished populating, restart
         if (remainingBombs > 0) {
             this.populateBombsProbability(remainingBombs);
         }
@@ -208,11 +223,11 @@ public class Game extends JFrame{
                 }
 
                 double probability = currentCell.calculateProbabilityOfBomb(this.firstCell.col, this.firstCell.row, this.gridSize);
-                double intensity = Math.min(Math.log(1 / probability) * 20, 255);
+                double intensity = probability * 15 * 255;
 
-                // the brighter the color, the more likely it is to
-                // not have been selected as a bomb
                 currentCell.setBackground(new Color(0, 0, (int)(intensity)));
+                currentCell.setForeground(Color.YELLOW);
+                currentCell.setText((int)(probability * 100) + "%");
             }
         }
     }

--- a/Menu.java
+++ b/Menu.java
@@ -10,6 +10,7 @@ public class Menu extends JFrame {
     public int windowSize;
     public int selectedGridSize;
     public int selectedBombAmount;
+    public int selectedMaxProbability;
 
     public boolean useProbability;
     public boolean drawProbabilities;
@@ -75,10 +76,12 @@ public class Menu extends JFrame {
         }
 
         this.windowSize = windowSize;
-        this.setMinimumSize(new Dimension(600, 600));
+        this.setMinimumSize(new Dimension(600, 800));
         // default grid size & bomb amount (medium difficulty)
         this.selectedGridSize = 20;
         this.selectedBombAmount = 60;
+
+        this.selectedMaxProbability = 8;
 
         this.useProbability = true;
         this.drawProbabilities = false;
@@ -116,6 +119,9 @@ public class Menu extends JFrame {
         JCheckBox useProbabilityToggle = new JCheckBox("Use probability-based bomb population?", this.useProbability);
         JCheckBox drawProbabilitiesToggle = new JCheckBox("Draw probability of cell being picked as bomb?", this.drawProbabilities);
         JCheckBox drawPopulationRingsToggle = new JCheckBox("Draw rings used while populating bombs?", this.drawPopulationRings);
+
+        JSlider maxProbabilitySlider = new JSlider(JSlider.HORIZONTAL, 0, 100, this.selectedMaxProbability);
+        JLabel maxProbabilityLabel = new JLabel("Max. probability: " + this.selectedMaxProbability + "%");
 
         JPanel difficultyPanel = new JPanel();
 
@@ -189,6 +195,18 @@ public class Menu extends JFrame {
         constraints.gridy = 11;
         add(drawPopulationRingsToggle, constraints);
 
+        constraints.gridx = 0;
+        constraints.gridy = 12;
+        maxProbabilitySlider.setMajorTickSpacing(20);
+        maxProbabilitySlider.setMinorTickSpacing(5);
+        maxProbabilitySlider.setPaintTicks(true);
+        maxProbabilitySlider.setPaintLabels(true);
+        add(maxProbabilitySlider, constraints);
+
+        constraints.gridx = 0;
+        constraints.gridy = 13;
+        add(maxProbabilityLabel, constraints);
+
         this.setDifficulty(this.selectedGridSize, this.selectedBombAmount);
 
         Menu self = this;
@@ -196,7 +214,9 @@ public class Menu extends JFrame {
             @Override
             public void actionPerformed(ActionEvent e) {
                     // Start game and stop menu
-                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount, self.useProbability, self.drawProbabilities, self.drawPopulationRings);
+                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount, self.selectedMaxProbability,
+                                         self.useProbability, self.drawProbabilities, self.drawPopulationRings);
+                                         
                     game.run();
                     self.stop();
                 }
@@ -254,6 +274,8 @@ public class Menu extends JFrame {
                 self.useProbability = selected;
                 drawProbabilitiesToggle.setVisible(selected);
                 drawPopulationRingsToggle.setVisible(selected);
+                maxProbabilitySlider.setVisible(selected);
+                maxProbabilityLabel.setVisible(selected);
 
                 if (!self.useProbability) {
                     self.drawProbabilities = false;
@@ -288,6 +310,13 @@ public class Menu extends JFrame {
                     self.drawProbabilities = false;
                     drawProbabilitiesToggle.setSelected(false);
                 }
+            }
+        });
+        maxProbabilitySlider.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e){
+                self.selectedMaxProbability = maxProbabilitySlider.getValue();
+                maxProbabilityLabel.setText("Max. Probability: " + self.selectedMaxProbability + "%");
             }
         });
     }

--- a/Menu.java
+++ b/Menu.java
@@ -11,6 +11,9 @@ public class Menu extends JFrame {
     public int selectedGridSize;
     public int selectedBombAmount;
 
+    public boolean useProbability;
+    public boolean drawProbabilities;
+
     private JLabel selectDifficultyLabel;
 
     private JSlider gridSizeSlider;
@@ -72,9 +75,13 @@ public class Menu extends JFrame {
         }
 
         this.windowSize = windowSize;
+        this.setMinimumSize(new Dimension(600, 600));
         // default grid size & bomb amount (medium difficulty)
         this.selectedGridSize = 20;
         this.selectedBombAmount = 60;
+
+        this.useProbability = true;
+        this.drawProbabilities = false;
 
         setLayout(new GridBagLayout());
         GridBagConstraints constraints = new GridBagConstraints();
@@ -86,6 +93,9 @@ public class Menu extends JFrame {
 
         this.selectDifficultyLabel = new JLabel("Select Difficulty (Medium)");
         this.selectDifficultyLabel.setFont(new Font("Arial", Font.ITALIC, 18));
+
+        JLabel optionsLabel = new JLabel("More Options");
+        optionsLabel.setFont(new Font("Arial", Font.ITALIC, 18));
 
         JButton startGameButton = new JButton("Start Game");
         startGameButton.setFocusPainted(false);
@@ -101,6 +111,9 @@ public class Menu extends JFrame {
 
         JButton customDifficultyButton = new JButton("Custom");
         customDifficultyButton.setFocusPainted(false);
+
+        JCheckBox useProbabilityToggle = new JCheckBox("Use probability-based bomb population?", this.useProbability);
+        JCheckBox drawProbabilitiesToggle = new JCheckBox("Draw probability of cell being picked as bomb?", this.drawProbabilities);
 
         JPanel difficultyPanel = new JPanel();
 
@@ -158,6 +171,18 @@ public class Menu extends JFrame {
         bombAmountLabel.setVisible(false);
         add(bombAmountLabel, constraints);
 
+        constraints.gridx = 0;
+        constraints.gridy = 8;
+        add(optionsLabel, constraints);
+
+        constraints.gridx = 0;
+        constraints.gridy = 9;
+        add(useProbabilityToggle, constraints);
+
+        constraints.gridx = 0;
+        constraints.gridy = 10;
+        add(drawProbabilitiesToggle, constraints);
+
         this.setDifficulty(this.selectedGridSize, this.selectedBombAmount);
 
         Menu self = this;
@@ -165,7 +190,7 @@ public class Menu extends JFrame {
             @Override
             public void actionPerformed(ActionEvent e) {
                     // Start game and stop menu
-                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount);
+                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount, self.useProbability, self.drawProbabilities);
                     game.run();
                     self.stop();
                 }
@@ -214,5 +239,28 @@ public class Menu extends JFrame {
                 self.updateCustomDifficulty();
             }
         });
+
+        useProbabilityToggle.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                boolean selected = (e.getStateChange() == 1);
+
+                self.useProbability = selected;
+                drawProbabilitiesToggle.setVisible(selected);
+
+                if (!self.useProbability) {
+                    self.drawProbabilities = false;
+                }
+            }
+        });
+        drawProbabilitiesToggle.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                boolean selected = (e.getStateChange() == 1);
+
+                self.drawProbabilities = selected;
+            }
+        });
+            
     }
 }

--- a/Menu.java
+++ b/Menu.java
@@ -13,6 +13,7 @@ public class Menu extends JFrame {
 
     public boolean useProbability;
     public boolean drawProbabilities;
+    public boolean drawPopulationRings;
 
     private JLabel selectDifficultyLabel;
 
@@ -22,7 +23,6 @@ public class Menu extends JFrame {
     private JLabel bombAmountLabel;
 
     private ImageIcon menuIcon;
-
 
     public void updateCustomDifficulty() {
         this.gridSizeLabel.setText("Grid size: " + this.gridSizeSlider.getValue());
@@ -82,6 +82,7 @@ public class Menu extends JFrame {
 
         this.useProbability = true;
         this.drawProbabilities = false;
+        this.drawPopulationRings = false;
 
         setLayout(new GridBagLayout());
         GridBagConstraints constraints = new GridBagConstraints();
@@ -114,6 +115,7 @@ public class Menu extends JFrame {
 
         JCheckBox useProbabilityToggle = new JCheckBox("Use probability-based bomb population?", this.useProbability);
         JCheckBox drawProbabilitiesToggle = new JCheckBox("Draw probability of cell being picked as bomb?", this.drawProbabilities);
+        JCheckBox drawPopulationRingsToggle = new JCheckBox("Draw rings used while populating bombs?", this.drawPopulationRings);
 
         JPanel difficultyPanel = new JPanel();
 
@@ -183,6 +185,10 @@ public class Menu extends JFrame {
         constraints.gridy = 10;
         add(drawProbabilitiesToggle, constraints);
 
+        constraints.gridx = 0;
+        constraints.gridy = 11;
+        add(drawPopulationRingsToggle, constraints);
+
         this.setDifficulty(this.selectedGridSize, this.selectedBombAmount);
 
         Menu self = this;
@@ -190,7 +196,7 @@ public class Menu extends JFrame {
             @Override
             public void actionPerformed(ActionEvent e) {
                     // Start game and stop menu
-                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount, self.useProbability, self.drawProbabilities);
+                    Game game = new Game(self.selectedGridSize, self.selectedBombAmount, self.useProbability, self.drawProbabilities, self.drawPopulationRings);
                     game.run();
                     self.stop();
                 }
@@ -247,9 +253,14 @@ public class Menu extends JFrame {
 
                 self.useProbability = selected;
                 drawProbabilitiesToggle.setVisible(selected);
+                drawPopulationRingsToggle.setVisible(selected);
 
                 if (!self.useProbability) {
                     self.drawProbabilities = false;
+                    self.drawPopulationRings = false;
+
+                    drawProbabilitiesToggle.setSelected(false);
+                    drawPopulationRingsToggle.setSelected(false);
                 }
             }
         });
@@ -259,8 +270,25 @@ public class Menu extends JFrame {
                 boolean selected = (e.getStateChange() == 1);
 
                 self.drawProbabilities = selected;
+
+                if (selected && self.drawPopulationRings) {
+                    self.drawPopulationRings = false;
+                    drawPopulationRingsToggle.setSelected(false);
+                }
             }
         });
-            
+        drawPopulationRingsToggle.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                boolean selected = (e.getStateChange() == 1);
+
+                self.drawPopulationRings = selected;
+
+                if (selected && self.drawProbabilities) {
+                    self.drawProbabilities = false;
+                    drawProbabilitiesToggle.setSelected(false);
+                }
+            }
+        });
     }
 }

--- a/Menu.java
+++ b/Menu.java
@@ -12,6 +12,7 @@ public class Menu extends JFrame {
     public int selectedBombAmount;
     public int selectedMaxProbability;
 
+    public boolean displayMoreOptions;
     public boolean useProbability;
     public boolean drawProbabilities;
     public boolean drawPopulationRings;
@@ -83,6 +84,7 @@ public class Menu extends JFrame {
 
         this.selectedMaxProbability = 8;
 
+        this.displayMoreOptions = false;
         this.useProbability = true;
         this.drawProbabilities = false;
         this.drawPopulationRings = false;
@@ -98,8 +100,7 @@ public class Menu extends JFrame {
         this.selectDifficultyLabel = new JLabel("Select Difficulty (Medium)");
         this.selectDifficultyLabel.setFont(new Font("Arial", Font.ITALIC, 18));
 
-        JLabel optionsLabel = new JLabel("More Options");
-        optionsLabel.setFont(new Font("Arial", Font.ITALIC, 18));
+        JButton optionsButton = new JButton("More Options");
 
         JButton startGameButton = new JButton("Start Game");
         startGameButton.setFocusPainted(false);
@@ -181,18 +182,21 @@ public class Menu extends JFrame {
 
         constraints.gridx = 0;
         constraints.gridy = 8;
-        add(optionsLabel, constraints);
+        add(optionsButton, constraints);
 
         constraints.gridx = 0;
         constraints.gridy = 9;
+        useProbabilityToggle.setVisible(this.displayMoreOptions);
         add(useProbabilityToggle, constraints);
 
         constraints.gridx = 0;
         constraints.gridy = 10;
+        drawProbabilitiesToggle.setVisible(this.displayMoreOptions);
         add(drawProbabilitiesToggle, constraints);
 
         constraints.gridx = 0;
         constraints.gridy = 11;
+        drawPopulationRingsToggle.setVisible(this.displayMoreOptions);
         add(drawPopulationRingsToggle, constraints);
 
         constraints.gridx = 0;
@@ -201,10 +205,12 @@ public class Menu extends JFrame {
         maxProbabilitySlider.setMinorTickSpacing(5);
         maxProbabilitySlider.setPaintTicks(true);
         maxProbabilitySlider.setPaintLabels(true);
+        maxProbabilitySlider.setVisible(this.displayMoreOptions);
         add(maxProbabilitySlider, constraints);
 
         constraints.gridx = 0;
         constraints.gridy = 13;
+        maxProbabilityLabel.setVisible(this.displayMoreOptions);
         add(maxProbabilityLabel, constraints);
 
         this.setDifficulty(this.selectedGridSize, this.selectedBombAmount);
@@ -266,6 +272,19 @@ public class Menu extends JFrame {
             }
         });
 
+        optionsButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                    self.displayMoreOptions = !self.displayMoreOptions;
+                    useProbabilityToggle.setVisible(self.displayMoreOptions);
+
+                    boolean displayCustomMoreOptions = self.displayMoreOptions && self.useProbability;
+                    drawProbabilitiesToggle.setVisible(displayCustomMoreOptions);
+                    drawPopulationRingsToggle.setVisible(displayCustomMoreOptions);
+                    maxProbabilitySlider.setVisible(displayCustomMoreOptions);
+                    maxProbabilityLabel.setVisible(displayCustomMoreOptions);
+                }
+        });
         useProbabilityToggle.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
@@ -316,7 +335,7 @@ public class Menu extends JFrame {
             @Override
             public void stateChanged(ChangeEvent e){
                 self.selectedMaxProbability = maxProbabilitySlider.getValue();
-                maxProbabilityLabel.setText("Max. Probability: " + self.selectedMaxProbability + "%");
+                maxProbabilityLabel.setText("Max. probability: " + self.selectedMaxProbability + "%");
             }
         });
     }


### PR DESCRIPTION
This pr makes it so that the likeliness of a cell being picked as a bomb depends on how far away it is from the first cell clicked (and the grid size), so that it is less likely for the player to have to guess at the start and therefore throughout the whole game.

I also added some GUI elements in the menu that allow you to disable this option to play the classic version of minesweeper, and also do display the probabilities of each cell as they are computed so that you can see what's going on.

closes #12 without using the solver but still less guessing is required